### PR TITLE
Add function for utf-16 compression

### DIFF
--- a/src/compress.rs
+++ b/src/compress.rs
@@ -98,6 +98,12 @@ pub fn compress_str(input: &str) -> Vec<u32> {
 }
 
 #[inline]
+pub fn compress_to_utf16(input: &str) -> String {
+    let buf = compress(input, 15, |n| { n + 32 });
+    buf.iter().map(|i| char::from_u32(*i).unwrap()).collect()
+}
+
+#[inline]
 pub fn compress_uri(data: &str) -> Vec<u32> {
     compress(&data, 6, |n| {
         u32::from(URI_KEY.chars().nth(n as usize).unwrap())

--- a/src/compress.rs
+++ b/src/compress.rs
@@ -100,7 +100,9 @@ pub fn compress_str(input: &str) -> Vec<u32> {
 #[inline]
 pub fn compress_to_utf16(input: &str) -> String {
     let buf = compress(input, 15, |n| n + 32);
-    buf.iter().map(|i| std::char::from_u32(*i).unwrap()).collect()
+    buf.iter()
+        .map(|i| std::char::from_u32(*i).unwrap())
+        .collect()
 }
 
 #[inline]

--- a/src/compress.rs
+++ b/src/compress.rs
@@ -99,7 +99,7 @@ pub fn compress_str(input: &str) -> Vec<u32> {
 
 #[inline]
 pub fn compress_to_utf16(input: &str) -> String {
-    let buf = compress(input, 15, |n| { n + 32 });
+    let buf = compress(input, 15, |n| n + 32);
     buf.iter().map(|i| char::from_u32(*i).unwrap()).collect()
 }
 

--- a/src/compress.rs
+++ b/src/compress.rs
@@ -100,7 +100,7 @@ pub fn compress_str(input: &str) -> Vec<u32> {
 #[inline]
 pub fn compress_to_utf16(input: &str) -> String {
     let buf = compress(input, 15, |n| n + 32);
-    buf.iter().map(|i| char::from_u32(*i).unwrap()).collect()
+    buf.iter().map(|i| std::char::from_u32(*i).unwrap()).collect()
 }
 
 #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(assoc_char_funcs)]
 #![forbid(unsafe_code)]
 
 mod compress;
@@ -11,6 +12,7 @@ pub use crate::{
         compress,
         compress_str,
         compress_uri,
+        compress_to_utf16
     },
     decompress::{
         decompress,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,8 +11,8 @@ pub use crate::{
     compress::{
         compress,
         compress_str,
+        compress_to_utf16,
         compress_uri,
-        compress_to_utf16
     },
     decompress::{
         decompress,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(assoc_char_funcs)]
 #![forbid(unsafe_code)]
 
 mod compress;

--- a/tests/common_legacy.rs
+++ b/tests/common_legacy.rs
@@ -1,4 +1,11 @@
-use lz_string::{compress_str, compress_uri, decompress_str, decompress_uri, str_to_u32_vec, compress_to_utf16};
+use lz_string::{
+    compress_str,
+    compress_to_utf16,
+    compress_uri,
+    decompress_str,
+    decompress_uri,
+    str_to_u32_vec,
+};
 
 const RED_STR: &str = "red";
 

--- a/tests/common_legacy.rs
+++ b/tests/common_legacy.rs
@@ -1,10 +1,4 @@
-use lz_string::{
-    compress_str,
-    compress_uri,
-    decompress_str,
-    decompress_uri,
-    str_to_u32_vec,
-};
+use lz_string::{compress_str, compress_uri, decompress_str, decompress_uri, str_to_u32_vec, compress_to_utf16};
 
 const RED_STR: &str = "red";
 
@@ -27,6 +21,12 @@ pub fn round_red() {
 pub fn compress_red() {
     let compressed = compress_str(&RED_STR);
     assert_eq!(str_to_u32_vec("ᎅ〦䀀"), compressed);
+}
+
+#[test]
+pub fn compress_red_to_utf16() {
+    let compressed = compress_to_utf16(&RED_STR);
+    assert_eq!("\u{9e2}䰩䠠".to_string(), compressed);
 }
 
 #[test]


### PR DESCRIPTION
This PR adds a function analog to [this one](https://github.com/pieroxy/lz-string/blob/b2e0b270a9f3cf330b778b777385fcba384a1a02/libs/lz-string.js#L47-L50-50) that compresses to utf-16 encoding. Our project would benefit from having this function available directly from the crate and hopefully others will too. Please let me know if you need any changes, more tests or even the decompress method for example.

Since `char::from_u32` is still unstable (see https://github.com/rust-lang/rust/issues/71763) it could take some time before this can be merged.